### PR TITLE
Use timezone aware object for UTC

### DIFF
--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim AS e2etest
+FROM python:3.12-slim AS e2etest
 
 COPY ./tests/e2e/requirements-dev.txt /tests/e2e/requirements-dev.txt
 RUN python -m pip install --upgrade pip

--- a/tests/utils/cloud.py
+++ b/tests/utils/cloud.py
@@ -13,7 +13,7 @@ def generate_account_signature(
     """
     Create account signature for azure request
     """
-    expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
+    expiry = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=lifespan)
     if permission == None:
         permission = blob.AccountSasPermissions(read=True)
     if resource_types == None:
@@ -37,7 +37,7 @@ def generate_container_signature(
     """
     Create container signature for azure request
     """
-    expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
+    expiry = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=lifespan)
     if permission == None:
         permission = blob.ContainerSasPermissions(read=True)
 
@@ -61,7 +61,7 @@ def generate_directory_signature(
     Create directory signature for azure request
     """
     from azure.storage import filedatalake
-    expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
+    expiry = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=lifespan)
     if permission == None:
         permission = filedatalake.FileSasPermissions(read=True)
 
@@ -85,7 +85,7 @@ def generate_blob_signature(
     """
     Create blob signature for azure request
     """
-    expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
+    expiry = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=lifespan)
     if permission == None:
         permission = blob.BlobSasPermissions(read=True)
 


### PR DESCRIPTION
Fix DeprecationWarning.

DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)