### PR TITLE
Fix casing do not match warnings

### DIFF
--- a/tests/memory/Dockerfile
+++ b/tests/memory/Dockerfile
@@ -25,11 +25,11 @@ ARG BUILD_DIR="build"
 RUN cmake -S . -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE=Debug -DGTEST=OFF -DMEMORYTEST=ON -DBUILD_CCORE=ON -DCMAKE_PREFIX_PATH=/open-vds
 RUN cmake --build "${BUILD_DIR}" || exit 1
 
-ENV EXECUTABLE_PATH "/${BUILD_DIR}/tests/memorytests"
+ENV EXECUTABLE_PATH="/${BUILD_DIR}/tests/memorytests"
 # openvds suppressions are presented in debug mode so it is easier to see the errors
 # thus why openvds itself should be compiled in debug mode to match those errors
-ENV VALGRIND_SUPPRESSION_PATH "/tests/memory/valgrind_alpine.supp, /tests/memory/openvds_debug.supp"
+ENV VALGRIND_SUPPRESSION_PATH="/tests/memory/valgrind_alpine.supp, /tests/memory/openvds_debug.supp"
 
 WORKDIR /tests
-ENV PYTHONPATH "${PYTHONPATH}:/tests"
+ENV PYTHONPATH="${PYTHONPATH}:/tests"
 ENTRYPOINT ["python", "memory/memory.py"]

--- a/tests/memory/Dockerfile
+++ b/tests/memory/Dockerfile
@@ -1,6 +1,6 @@
 # this must be openvds image in debug mode
 ARG OPENVDS_IMAGE=openvdsdebug
-FROM ${OPENVDS_IMAGE} as openvds
+FROM ${OPENVDS_IMAGE} AS openvds
 
 FROM python:3.11-alpine
 

--- a/tests/performance/Dockerfile
+++ b/tests/performance/Dockerfile
@@ -10,7 +10,7 @@ RUN curl \
     -o k6-${k6_version}.tar.gz
 RUN tar xzf k6-${k6_version}.tar.gz -C k6 --strip-components=1
 
-ENV PATH "$PATH:k6"
+ENV PATH="$PATH:k6"
 
 ARG prometheus_version=2.50.1
 RUN mkdir prometheus
@@ -19,10 +19,10 @@ RUN curl \
     -o prometheus-${prometheus_version}.tar.gz
 RUN tar xzf prometheus-${prometheus_version}.tar.gz -C prometheus --strip-components=1
 
-ENV PATH "$PATH:prometheus"
+ENV PATH="$PATH:prometheus"
 
 COPY ./tests/utils /tests/utils
 COPY ./tests/performance /tests/performance
 RUN chmod +x /tests/performance/execute.sh
 RUN python -m pip install -r /tests/performance/requirements-dev.txt
-ENV PYTHONPATH "${PYTHONPATH}:/tests"
+ENV PYTHONPATH="${PYTHONPATH}:/tests"


### PR DESCRIPTION
Building the docker image give the following warning:
- FromAsCasing: 'as' and 'FROM' keywords' casing do not match