### PR TITLE
Use python 3.12 in performance tests

### DIFF
--- a/tests/performance/Dockerfile
+++ b/tests/performance/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 RUN apt-get update && apt-get install -y \
     curl \
     gettext-base


### PR DESCRIPTION
Performance tests must also use python 3.12 due to 764bd59bc8f69fe34c11bc7a976197b4c2707b81